### PR TITLE
Install app as pycsw user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           paths:
             - .venv
       - setup_remote_docker
-      - run: pipenv run molecule test --all
+      - run: pipenv run test
 
   snyk:
     docker:

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-ansible = "*"
+ansible = "~=2.6"
 molecule = {extras = ["docker"],version = "*"}
 
 [packages]

--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,6 @@ molecule = {extras = ["docker"],version = "*"}
 
 [requires]
 python_version = "3.6"
+
+[scripts]
+test = "molecule test --all"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "36a4265aa97f53908f120613884e1c859985d7f9d51baec7fc9ff3d13a1bed16"
+            "sha256": "019afd9fc1dbca2dc72373b7ff3d9fa97abc79ccb8e25b6dc1f0eefc89a2a6ee"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -39,8 +39,8 @@ def test_app_current_link(host):
 
     assert current.exists
     assert current.is_symlink
-    assert current.user == 'root'
-    assert current.group == 'root'
+    assert current.user == 'pycsw'
+    assert current.group == 'pycsw'
     assert current.linked_to == expected_deployment
 
 
@@ -50,8 +50,8 @@ def test_app_release_dir(host):
 
     assert src.exists
     assert src.is_directory
-    assert src.user == 'root'
-    assert src.group == 'root'
+    assert src.user == 'pycsw'
+    assert src.group == 'pycsw'
     assert src.mode == 0o755
 
 
@@ -61,8 +61,8 @@ def test_app_virtualenv_dir(host):
 
     assert virtualenv.exists
     assert virtualenv.is_directory
-    assert virtualenv.user == 'root'
-    assert virtualenv.group == 'root'
+    assert virtualenv.user == 'pycsw'
+    assert virtualenv.group == 'pycsw'
     assert virtualenv.mode == 0o755
 
 
@@ -71,8 +71,8 @@ def test_app_virtualenv_python(host):
                        % (app_user, deployment_version))
 
     assert python.exists
-    assert python.user == 'root'
-    assert python.group == 'root'
+    assert python.user == 'pycsw'
+    assert python.group == 'pycsw'
     assert python.mode == 0o755
 
 

--- a/molecule/worker/tests/test_default.py
+++ b/molecule/worker/tests/test_default.py
@@ -39,8 +39,8 @@ def test_app_current_link(host):
 
     assert current.exists
     assert current.is_symlink
-    assert current.user == 'root'
-    assert current.group == 'root'
+    assert current.user == 'pycsw'
+    assert current.group == 'pycsw'
     assert current.linked_to == expected_deployment
 
 
@@ -50,8 +50,8 @@ def test_app_release_dir(host):
 
     assert src.exists
     assert src.is_directory
-    assert src.user == 'root'
-    assert src.group == 'root'
+    assert src.user == 'pycsw'
+    assert src.group == 'pycsw'
     assert src.mode == 0o755
 
 
@@ -61,8 +61,8 @@ def test_app_virtualenv_dir(host):
 
     assert virtualenv.exists
     assert virtualenv.is_directory
-    assert virtualenv.user == 'root'
-    assert virtualenv.group == 'root'
+    assert virtualenv.user == 'pycsw'
+    assert virtualenv.group == 'pycsw'
     assert virtualenv.mode == 0o755
 
 
@@ -71,8 +71,8 @@ def test_app_virtualenv_python(host):
                        % (app_user, deployment_version))
 
     assert python.exists
-    assert python.user == 'root'
-    assert python.group == 'root'
+    assert python.user == 'pycsw'
+    assert python.group == 'pycsw'
     assert python.mode == 0o755
 
 
@@ -93,6 +93,9 @@ def test_supervisor_conf(host):
     conf = host.file('/etc/supervisor/conf.d/pycsw.conf')
 
     assert conf.exists
+    assert conf.user == 'root'
+    assert conf.group == 'root'
+    assert conf.mode == 0o644
 
 
 def test_pycsw_worker_services(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,45 @@
   set_fact:
     tasks_hooks_path: "{{ role_path }}/tasks"
 
+- name: install os packages
+  apt: name={{ [role_packages, pycsw_app_os_packages] | flatten }} state=present
+  vars:
+    role_packages:
+      - cron
+      - git
+      - python-setuptools  # Needed for ansible pip
+      - rsync  # Needed for ansistrano role
+      - supervisor
+
+- name: ensure supervisor is started and enabled
+  service: name=supervisor state=started enabled=yes
+
+- name: create pycsw app user
+  user: name=pycsw home={{ pycsw_app_home }} system=yes state=present comment="pycsw application"
+
+- name: create pycsw app home directory
+  file: dest={{ pycsw_app_home }} owner=pycsw group=pycsw mode=0755 state=directory
+
+- name: create logs directory
+  file: dest=/var/log/pycsw owner=pycsw group=pycsw mode=0750 state=directory
+
+- name: create config directory
+  file: dest=/etc/pycsw owner=pycsw group=pycsw mode=0755 state=directory
+
+- name: install requested python version with pyenv
+  include_role:
+    name: avanov.pyenv
+  vars:
+    pyenv_path: "{{ pycsw_app_home }}/.pyenv"
+    pyenv_owner: pycsw
+    pyenv_global: system
+    pyenv_python_versions: ["{{ pycsw_python_version }}"]
+    pyenv_virtualenvs: []
+
 - name: ansistrano deploy
   import_role: name=ansistrano.deploy
+  become: true
+  become_user: pycsw
   vars:
     ansistrano_allow_anonymous_stats: false
     ansistrano_deploy_to: "{{ pycsw_app_home }}"

--- a/tasks/setup_before.yml
+++ b/tasks/setup_before.yml
@@ -1,39 +1,4 @@
 ---
-- name: install os packages
-  apt: name={{ [role_packages, pycsw_app_os_packages] | flatten }} state=present
-  vars:
-    role_packages:
-      - cron
-      - git
-      - python-setuptools  # Needed for ansible pip
-      - rsync  # Needed for ansistrano role
-      - supervisor
-
-- name: ensure supervisor is started and enabled
-  service: name=supervisor state=started enabled=yes
-
-- name: create pycsw app user
-  user: name=pycsw home={{ pycsw_app_home }} system=yes state=present comment="pycsw application"
-
-- name: create pycsw app home directory
-  file: dest={{ pycsw_app_home }} owner=pycsw group=pycsw mode=0755 state=directory
-
-- name: create logs directory
-  file: dest=/var/log/pycsw owner=pycsw group=pycsw mode=0750 state=directory
-
-- name: create config directory
-  file: dest=/etc/pycsw owner=pycsw group=pycsw mode=0755 state=directory
-
-- name: install requested python version with pyenv
-  include_role:
-    name: avanov.pyenv
-  vars:
-    pyenv_path: "{{ pycsw_app_home }}/.pyenv"
-    pyenv_owner: pycsw
-    pyenv_global: system
-    pyenv_python_versions: ["{{ pycsw_python_version }}"]
-    pyenv_virtualenvs: []
-
 # Having virtualenv in python 2 and 3 simplifies things a little
 - name: install virtualenv
   pip: >-
@@ -41,5 +6,3 @@
     name=virtualenv
     state=present
     umask=0022
-  become: true
-  become_user: pycsw

--- a/tasks/symlink_after.yml
+++ b/tasks/symlink_after.yml
@@ -1,14 +1,20 @@
 ---
 - name: create supervisor config
   copy: src=supervisor_{{ pycsw_role }}.conf.j2 dest=/etc/supervisor/conf.d/pycsw.conf owner=root group=root mode=0644
+  become: true
+  become_user: root
   notify: reload supervisor
 
 - name: create crontab
   copy: src=worker.cron dest=/etc/cron.d/pycsw mode=0644
+  become: true
+  become_user: root
   when: pycsw_role == "worker"
 
 - name: create pycsw-collection.cfg
   template: src=pycsw.cfg.j2 dest=/etc/pycsw/pycsw-collection.cfg owner=root group=pycsw mode=0640
+  become: true
+  become_user: root
   vars:
     pycsw_abstract: "{{ pycsw_abstract_collection }}"
     pycsw_app_url: "{{ pycsw_base_url }}/csw"
@@ -16,6 +22,8 @@
 
 - name: create pycsw-all.cfg
   template: src=pycsw.cfg.j2 dest=/etc/pycsw/pycsw-all.cfg owner=root group=pycsw mode=0640
+  become: true
+  become_user: root
   vars:
     pycsw_abstract: "{{ pycsw_abstract_collection }}"
     pycsw_app_url: "{{ pycsw_base_url }}/csw-all"
@@ -28,6 +36,8 @@
 # changed, they will be picked up on the next run.
 - name: restart pycsw web services
   supervisorctl: name={{ item }} state=restarted
+  become: true
+  become_user: root
   loop:
     - pycsw-collection
     - pycsw-all


### PR DESCRIPTION
The ansistrano.deploy role does not support any configuration for users or ownership of the app directories it creates. Instead it assumes you're installing as the user. Because of our umask 027, the app is not world readable, so instead, we must install it as the pycsw user.